### PR TITLE
add missing semi-colon into refreshAccount method

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -111,7 +111,7 @@ class Client
     public function refreshAccount(RefreshAccountDTO $refreshAccount): ResponseInterface
     {
        $payload = (array) $refreshAccount;
-       $payload['scope'] = $payload['scope'] ? $payload['scope'] : [ScopeEnum::PROFILE]
+       $payload['scope'] = $payload['scope'] ? $payload['scope'] : [ScopeEnum::PROFILE];
 
        return $this->api->post('/xact/sdk/refresh', ['json' => $payload]);
     }


### PR DESCRIPTION
# Description
This PR is a fix of missing semi-colon in the refreshAccount method.

# PR Checklist

- [x] Unit tests have been added or updated if necessary
- [x] Changelog has been updated if necessary
- [x] Documentation has been updated if necessary

# Issue
A semi-colon was missing in the refreshAccount method.
